### PR TITLE
Fixed some bugs about parameters and updated comments

### DIFF
--- a/contextual_loss/functional.py
+++ b/contextual_loss/functional.py
@@ -33,7 +33,8 @@ def contextual_loss(x: torch.Tensor,
     cx_loss : torch.Tensor
         contextual loss between x and y (Eq (1) in the paper)
     """
-
+        
+    loss_type = loss_type.lower()
     assert x.size() == y.size(), 'input tensor must have the same size.'
     assert loss_type in LOSS_TYPES, f'select a loss type from {LOSS_TYPES}.'
 
@@ -86,7 +87,8 @@ def contextual_bilateral_loss(x: torch.Tensor,
     k_arg_max_NC : torch.Tensor
         indices to maximize similarity over channels.
     """
-
+    
+    loss_type = loss_type.lower()
     assert x.size() == y.size(), 'input tensor must have the same size.'
     assert loss_type in LOSS_TYPES, f'select a loss type from {LOSS_TYPES}.'
 

--- a/contextual_loss/functional.py
+++ b/contextual_loss/functional.py
@@ -70,6 +70,8 @@ def contextual_bilateral_loss(x: torch.Tensor,
         features of shape (N, C, H, W).
     y : torch.Tensor
         features of shape (N, C, H, W).
+    weight_sp : float, optional
+        a balancing weight between spatial and feature loss.
     band_width : float, optional
         a band-width parameter used to convert distance to similarity.
         in the paper, this is described as :math:`h`.

--- a/contextual_loss/functional.py
+++ b/contextual_loss/functional.py
@@ -59,7 +59,7 @@ def contextual_loss(x: torch.Tensor,
 def contextual_bilateral_loss(x: torch.Tensor,
                               y: torch.Tensor,
                               weight_sp: float = 0.1,
-                              band_width: float = 1.,
+                              band_width: float = 0.5,
                               loss_type: str = 'cosine'):
     """
     Computes Contextual Bilateral (CoBi) Loss between x and y,

--- a/contextual_loss/modules/contextual.py
+++ b/contextual_loss/modules/contextual.py
@@ -14,6 +14,9 @@ class ContextualLoss(nn.Module):
     ---
     band_width : int, optional
         a band_width parameter described as :math:`h` in the paper.
+    loss_type : str, optional
+        a loss type to measure the distance between features.
+        Note: `l1` and `l2` frequently raises OOM.
     use_vgg : bool, optional
         if you want to use VGG feature, set this `True`.
     vgg_layer : str, optional
@@ -35,6 +38,7 @@ class ContextualLoss(nn.Module):
             f'select a loss type from {LOSS_TYPES}.'
 
         self.band_width = band_width
+        self.loss_type = loss_type
 
         if use_vgg:
             self.vgg_model = VGG19()
@@ -63,4 +67,4 @@ class ContextualLoss(nn.Module):
             x = getattr(self.vgg_model(x), self.vgg_layer)
             y = getattr(self.vgg_model(y), self.vgg_layer)
 
-        return F.contextual_loss(x, y, self.band_width)
+        return F.contextual_loss(x, y, self.band_width, self.loss_type)

--- a/contextual_loss/modules/contextual.py
+++ b/contextual_loss/modules/contextual.py
@@ -32,7 +32,8 @@ class ContextualLoss(nn.Module):
                  vgg_layer: str = 'relu3_4'):
 
         super(ContextualLoss, self).__init__()
-
+        loss_type = loss_type.lower()
+        
         assert band_width > 0, 'band_width parameter must be positive.'
         assert loss_type in LOSS_TYPES,\
             f'select a loss type from {LOSS_TYPES}.'

--- a/contextual_loss/modules/contextual_bilateral.py
+++ b/contextual_loss/modules/contextual_bilateral.py
@@ -16,6 +16,9 @@ class ContextualBilateralLoss(nn.Module):
         a balancing weight between spatial and feature loss.
     band_width : int, optional
         a band_width parameter described as :math:`h` in the paper.
+    loss_type : str, optional
+        a loss type to measure the distance between features.
+        Note: `l1` and `l2` frequently raises OOM.
     use_vgg : bool, optional
         if you want to use VGG feature, set this `True`.
     vgg_layer : str, optional
@@ -39,6 +42,7 @@ class ContextualBilateralLoss(nn.Module):
         
         self.weight_sp = weight_sp
         self.band_width = band_width
+        self.loss_type = loss_type
 
         if use_vgg:
             self.vgg_model = VGG19()
@@ -67,4 +71,4 @@ class ContextualBilateralLoss(nn.Module):
             x = getattr(self.vgg_model(x), self.vgg_layer)
             y = getattr(self.vgg_model(y), self.vgg_layer)
 
-        return F.contextual_bilateral_loss(x, y, self.weight_sp, self.band_width)
+        return F.contextual_bilateral_loss(x, y, self.weight_sp, self.band_width, self.loss_type)

--- a/contextual_loss/modules/contextual_bilateral.py
+++ b/contextual_loss/modules/contextual_bilateral.py
@@ -36,7 +36,8 @@ class ContextualBilateralLoss(nn.Module):
         assert band_width > 0, 'band_width parameter must be positive.'
         assert loss_type in LOSS_TYPES,\
             f'select a loss type from {LOSS_TYPES}.'
-
+        
+        self.weight_sp = weight_sp
         self.band_width = band_width
 
         if use_vgg:
@@ -66,4 +67,4 @@ class ContextualBilateralLoss(nn.Module):
             x = getattr(self.vgg_model(x), self.vgg_layer)
             y = getattr(self.vgg_model(y), self.vgg_layer)
 
-        return F.contextual_bilateral_loss(x, y, self.band_width)
+        return F.contextual_bilateral_loss(x, y, self.weight_sp, self.band_width)

--- a/contextual_loss/modules/contextual_bilateral.py
+++ b/contextual_loss/modules/contextual_bilateral.py
@@ -35,7 +35,8 @@ class ContextualBilateralLoss(nn.Module):
                  vgg_layer: str = 'relu3_4'):
 
         super(ContextualBilateralLoss, self).__init__()
-
+        loss_type = loss_type.lower()
+        
         assert band_width > 0, 'band_width parameter must be positive.'
         assert loss_type in LOSS_TYPES,\
             f'select a loss type from {LOSS_TYPES}.'


### PR DESCRIPTION
I found some bugs and fixed it. Please check my pull request.

1. Parameter `loss_type` is being ignored in both `ContextualLoss` and `ContextualBilateralLoss`.
2. Parameter `band_width` in `ContextualBilateralLoss` is treated as `weight_sp`.
3. Parameter `loss_type` is better to compared in lower case.
4. Default value of parameter `band_width` in `ContextualBilateralLoss` is `0.5` but `F.contextual_bilateral_loss` have default value of `1.0`.

Thank you.